### PR TITLE
Make DB helpers async via aiosqlite

### DIFF
--- a/book_bot/requirements.txt
+++ b/book_bot/requirements.txt
@@ -1,3 +1,4 @@
 aiogram==3.13.1
 gigachat==0.1.35
 redis==5.1.1
+aiosqlite==0.19.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,5 @@ requires-python = ">=3.11"
 dependencies = [
     "aiogram>=3.20.0.post0",
     "gigachat>=0.1.39.post1",
+    "aiosqlite>=0.19.0",
 ]


### PR DESCRIPTION
## Summary
- use `aiosqlite` for database access
- switch `init_db`, `get_total_books` and `save_book` to async
- await new async functions in handlers
- add `aiosqlite` to dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f1c5f410c8326b502dd49342c1b04